### PR TITLE
Use external script for Google Analytics stuff

### DIFF
--- a/bc-mirador/generate_mirador_view.rb
+++ b/bc-mirador/generate_mirador_view.rb
@@ -76,13 +76,7 @@ def build_document(file)
 <head>
   <!-- Global site tag (gtag.js) - Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=UA-3008279-23"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-
-    gtag('config', 'UA-3008279-23');
-  </script>
+  <script src="/iiif/bc-mirador/gtag.js"></script>
   <title>#{identifier}</title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title above -->

### What does this PR do?
Loads separate gtag script instead of setting gtag params in the script tag.

### Motivation and context
It makes it easier to change Google Analytics params (e.g., enabling anonymizeIP) en masse.

### How has this been tested?
We've already implemented it in aspaceiiif. Adding it to this legacy script in case we ever need to regenerate views for old DigiTool MARC collections.

### How can a reviewer see the effects of these changes?
Run the script on a IIIF manifest.

### Related tickets
<!--- Please link to the Trello card or GitHub issue here -->

### Screenshots
<!-- Include relevant screenshots if necessary -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply -->
- [ ] I have tested this code.
- [ ] This PR requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have stakeholder approval to make this change.
